### PR TITLE
[#12] 예외 처리를 위한 클래스, 로직 작성

### DIFF
--- a/src/main/java/com/deploy/playtogether/common/dto/ApiResponse.java
+++ b/src/main/java/com/deploy/playtogether/common/dto/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.deploy.playtogether.common.dto;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+import com.deploy.playtogether.common.exception.StatusCode;
+import com.deploy.playtogether.common.exception.SuccessCode;
+
+import lombok.ToString;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+    public static final ApiResponse<String> SUCCESS = success("OK");
+
+    private StatusCode resultCode;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(null, "", data);
+    }
+
+    public static <T> ApiResponse<T> success(T data, SuccessCode successCode) {
+        return new ApiResponse<>(StatusCode.SUCCESS, successCode.getMessage(), data);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getStatusCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(errorCode.getStatusCode(), message, null);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/ErrorCode.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/ErrorCode.java
@@ -1,0 +1,59 @@
+package com.deploy.playtogether.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.deploy.playtogether.common.exception.StatusCode.*;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ErrorCode {
+    // 400 Bad Request
+    VALIDATION_EXCEPTION(BAD_REQUEST, "잘못된 요청입니다"),
+    VALIDATION_ENUM_VALUE_EXCEPTION(BAD_REQUEST, "잘못된 Enum 값 입니다"),
+    VALIDATION_REQUEST_MISSING_EXCEPTION(BAD_REQUEST, "필수적인 요청 값이 입력되지 않았습니다"),
+    VALIDATION_WRONG_TYPE_EXCEPTION(BAD_REQUEST, "잘못된 타입이 입력되었습니다."),
+    VALIDATION_SOCIAL_TYPE_EXCEPTION(BAD_REQUEST, "잘못된 소셜 프로바이더 입니다."),
+
+    // 401 UnAuthorized
+    UNAUTHORIZED_EXCEPTION(UNAUTHORIZED, "세션이 만료되었습니다. 다시 로그인 해주세요"),
+
+    // 403 Forbidden
+    FORBIDDEN_EXCEPTION(FORBIDDEN, "허용하지 않는 요청입니다."),
+
+    // 404 Not Found
+    NOT_FOUND_EXCEPTION(NOT_FOUND, "존재하지 않습니다"),
+    NOT_FOUND_USER_EXCEPTION(NOT_FOUND, "탈퇴하거나 존재하지 않는 유저입니다"),
+
+    // 405 Method Not Allowed
+    METHOD_NOT_ALLOWED_EXCEPTION(METHOD_NOT_ALLOWED, "지원하지 않는 메소드 입니다"),
+
+    // 406 Not Acceptable
+    NOT_ACCEPTABLE_EXCEPTION(NOT_ACCEPTABLE, "Not Acceptable"),
+
+    // 409 Conflict
+    CONFLICT_EXCEPTION(CONFLICT, "이미 존재합니다"),
+    CONFLICT_NICKNAME_EXCEPTION(CONFLICT, "이미 사용중인 닉네임입니다.\n다른 닉네임을 이용해주세요"),
+    CONFLICT_USER_EXCEPTION(CONFLICT, "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요"),
+
+    // 415 Unsupported Media Type
+    UNSUPPORTED_MEDIA_TYPE_EXCEPTION(UNSUPPORTED_MEDIA_TYPE, "해당하는 미디어 타입을 지원하지 않습니다."),
+
+    // 500 Internal Server Exception
+    INTERNAL_SERVER_EXCEPTION(INTERNAL_SERVER, "예상치 못한 서버 에러가 발생하였습니다."),
+
+    // 502 Bad Gateway
+    BAD_GATEWAY_EXCEPTION(BAD_GATEWAY, "일시적인 에러가 발생하였습니다.\n잠시 후 다시 시도해주세요!"),
+
+    // 503 Service UnAvailable
+    SERVICE_UNAVAILABLE_EXCEPTION(SERVICE_UNAVAILABLE, "현재 점검 중입니다.\n잠시 후 다시 시도해주세요!"),
+    ;
+
+    private final StatusCode statusCode;
+    private final String message;
+
+    public int getStatus() {
+        return statusCode.getStatus();
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/StatusCode.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/StatusCode.java
@@ -1,0 +1,27 @@
+package com.deploy.playtogether.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum StatusCode {
+    /**
+     * status code
+     */
+    SUCCESS(200),
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    NOT_FOUND(404),
+    METHOD_NOT_ALLOWED(405),
+    NOT_ACCEPTABLE(406),
+    CONFLICT(409),
+    UNSUPPORTED_MEDIA_TYPE(415),
+    INTERNAL_SERVER(500),
+    BAD_GATEWAY(502),
+    SERVICE_UNAVAILABLE(503);
+
+    private final int status;
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/SuccessCode.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/SuccessCode.java
@@ -1,0 +1,21 @@
+package com.deploy.playtogether.common.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.deploy.playtogether.common.exception.StatusCode.SUCCESS;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum SuccessCode {
+
+    SIGNUP_SUCCESS(SUCCESS, "회원가입이 완료되었습니다.");
+
+    private final StatusCode statusCode;
+    private final String message;
+
+    public int getStatus(){
+        return statusCode.getStatus();
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/BadGatewayException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/BadGatewayException.java
@@ -1,0 +1,10 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+
+public class BadGatewayException extends PlaytogetherException{
+
+    public BadGatewayException(String message) {
+        super(message, ErrorCode.BAD_GATEWAY_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/ConflictException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/ConflictException.java
@@ -1,0 +1,13 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+
+public class ConflictException extends PlaytogetherException{
+    public ConflictException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public ConflictException(String message) {
+        super(message, ErrorCode.CONFLICT_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/NotFoundException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/NotFoundException.java
@@ -1,0 +1,13 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+
+public class NotFoundException extends PlaytogetherException{
+    public NotFoundException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public NotFoundException(String message) {
+        super(message, ErrorCode.NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/PlaytogetherException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/PlaytogetherException.java
@@ -1,0 +1,18 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PlaytogetherException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public PlaytogetherException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public int getStatus() {
+        return errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/UnAuthorizedException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/UnAuthorizedException.java
@@ -1,0 +1,9 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+
+public class UnAuthorizedException extends PlaytogetherException{
+    public UnAuthorizedException(String message) {
+        super(message, ErrorCode.UNAUTHORIZED_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/common/exception/model/ValidationException.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/model/ValidationException.java
@@ -1,0 +1,13 @@
+package com.deploy.playtogether.common.exception.model;
+
+import com.deploy.playtogether.common.exception.ErrorCode;
+
+public class ValidationException extends PlaytogetherException{
+    public ValidationException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public ValidationException(String message) {
+        super(message, ErrorCode.VALIDATION_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/controller/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/com/deploy/playtogether/controller/advice/ControllerExceptionAdvice.java
@@ -1,0 +1,140 @@
+package com.deploy.playtogether.controller.advice;
+
+import com.deploy.playtogether.common.dto.ApiResponse;
+import com.deploy.playtogether.common.exception.model.PlaytogetherException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeException;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingRequestValueException;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
+
+import static com.deploy.playtogether.common.exception.ErrorCode.*;
+
+
+@Slf4j
+@RestControllerAdvice
+public class ControllerExceptionAdvice {
+
+    /**
+     * 400 BadRequest
+     * Spring Validation
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    protected ApiResponse<Object> handleBadRequest(final BindException e) {
+        log.error(e.getMessage());
+        FieldError fieldError = Objects.requireNonNull(e.getFieldError());
+        return ApiResponse.error(VALIDATION_EXCEPTION, String.format("%s (%s)", fieldError.getDefaultMessage(), fieldError.getField()));
+    }
+
+    /**
+     * 400 BadRequest
+     * 잘못된 Enum 값이 입된 경우 발생하는 Exception
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ApiResponse<Object> handleHttpMessageNotReadableException(final HttpMessageNotReadableException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(VALIDATION_ENUM_VALUE_EXCEPTION);
+    }
+
+    /**
+     * 400 BadRequest
+     * RequestParam, RequestPath, RequestPart 등의 필드가 입력되지 않은 경우 발생하는 Exception
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MissingRequestValueException.class)
+    protected ApiResponse<Object> handle(final MissingRequestValueException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(VALIDATION_REQUEST_MISSING_EXCEPTION);
+    }
+
+    /**
+     * 400 BadRequest
+     * 잘못된 타입이 입력된 경우 발생하는 Exception
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(TypeMismatchException.class)
+    protected ApiResponse<Object> handleTypeMismatchException(final TypeMismatchException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(VALIDATION_WRONG_TYPE_EXCEPTION, String.format("%s (%s)", VALIDATION_WRONG_TYPE_EXCEPTION.getMessage(), e.getValue()));
+    }
+
+    /**
+     * 400 BadRequest
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({
+            InvalidFormatException.class,
+            ServletRequestBindingException.class
+    })
+    protected ApiResponse<Object> handleInvalidFormatException(final Exception e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(VALIDATION_EXCEPTION);
+    }
+
+    /**
+     * 405 Method Not Allowed
+     * 지원하지 않은 HTTP method 호출 할 경우 발생하는 Exception
+     */
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ApiResponse<Object> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(METHOD_NOT_ALLOWED_EXCEPTION);
+    }
+
+    /**
+     * 406 Not Acceptable
+     */
+    @ResponseStatus(HttpStatus.NOT_ACCEPTABLE)
+    @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+    protected ApiResponse<Object> handleHttpMediaTypeNotAcceptableException(HttpMediaTypeNotAcceptableException e) {
+        log.error(e.getMessage());
+        return ApiResponse.error(NOT_ACCEPTABLE_EXCEPTION);
+    }
+
+    /**
+     * 415 UnSupported Media Type
+     * 지원하지 않는 미디어 타입인 경우 발생하는 Exception
+     */
+    @ResponseStatus(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+    @ExceptionHandler(HttpMediaTypeException.class)
+    protected ApiResponse<Object> handleHttpMediaTypeException(final HttpMediaTypeException e) {
+        log.error(e.getMessage(), e);
+        return ApiResponse.error(UNSUPPORTED_MEDIA_TYPE_EXCEPTION);
+    }
+
+    /**
+     * Playtogether Custom Exception
+     */
+    @ExceptionHandler(PlaytogetherException.class)
+    protected ResponseEntity<ApiResponse<Object>> handleBaseException(PlaytogetherException exception) {
+        log.error(exception.getMessage(), exception);
+        return ResponseEntity.status(exception.getStatus())
+                .body(ApiResponse.error(exception.getErrorCode()));
+    }
+
+    /**
+     * 500 Internal Server
+     */
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    protected ApiResponse<Object> handleException(final Exception exception) {
+        log.error(exception.getMessage(), exception);
+        return ApiResponse.error(INTERNAL_SERVER_EXCEPTION);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/controller/advice/WebDataBinderAdvice.java
+++ b/src/main/java/com/deploy/playtogether/controller/advice/WebDataBinderAdvice.java
@@ -1,0 +1,17 @@
+package com.deploy.playtogether.controller.advice;
+
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class WebDataBinderAdvice {
+    /**
+     * GET 메소드의 DTO에서도 별도의 setter를 열지 않아도 된다.
+     * 참고) https://jojoldu.tistory.com/407
+     */
+    @InitBinder
+    public void initBinder(WebDataBinder binder) {
+        binder.initDirectFieldAccess();
+    }
+}


### PR DESCRIPTION
## 🌈 PR 요약 / Linked Issue
close #12 
예외 처리를 위한 클래스, 로직 작성

## 📌 변경 사항
예외 처리를 위한 클래스(Custom Exception 클래스 작성)
예외 처리를 위한 Enum(StatusCode, ErrorCode, SusccesCode 추가)
GET 메서드에서 Setter를 사용하지 못하도록 Binder 추가
예외 처리를 위한 RestControllerAdvice 추가 
