### PR TITLE
[#41] 내가 만든 번개 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/deploy/playtogether/common/exception/SuccessCode.java
+++ b/src/main/java/com/deploy/playtogether/common/exception/SuccessCode.java
@@ -21,6 +21,7 @@ public enum SuccessCode {
     REPORT_LIGHT_SUCCESS(SUCCESS, "번개 신고가 완료되었습니다."),
     HOT_LIGHT_SUCCESS(SUCCESS, "인기 번개 조회 성공"),
     NEW_LIGHT_SUCCESS(SUCCESS, "최신 번개 조회 성공"),
+    OPEN_LIGHT_SUCCESS(SUCCESS, "내가 만든 번개 조회 성공"),
     ;
 
     private final StatusCode statusCode;

--- a/src/main/java/com/deploy/playtogether/controller/light/LightController.java
+++ b/src/main/java/com/deploy/playtogether/controller/light/LightController.java
@@ -3,18 +3,16 @@ package com.deploy.playtogether.controller.light;
 import com.deploy.playtogether.common.dto.ApiResponse;
 import com.deploy.playtogether.common.exception.SuccessCode;
 import com.deploy.playtogether.controller.light.dto.request.LightRequestDto;
+import com.deploy.playtogether.controller.light.dto.request.LightScrollRequest;
 import com.deploy.playtogether.controller.light.dto.request.ReportLightRequestDto;
 import com.deploy.playtogether.service.light.LightService;
 import com.deploy.playtogether.service.light.S3Service;
 import com.deploy.playtogether.service.light.dto.response.LightResponse;
+import com.deploy.playtogether.service.light.dto.response.LightResponseUsingCursorResponse;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -28,7 +26,7 @@ public class LightController {
     @ApiOperation("[인증] 번개 생성 API")
     @PostMapping(value = "/light/add/{crewId}/{userId}", consumes = "multipart/form-data")
     public ApiResponse createLight(@PathVariable final Long userId, @PathVariable final Long crewId,
-                                                     @ModelAttribute @Valid final LightRequestDto request){
+                                   @ModelAttribute @Valid final LightRequestDto request) {
         final List<String> imgPaths = s3Service.upload(request.getImages());
         lightService.createLight(userId, crewId, request.toServiceDto(), imgPaths);
         return ApiResponse.success(SuccessCode.LIGHT_ADD_SUCCESS);
@@ -36,21 +34,27 @@ public class LightController {
 
     @ApiOperation("[인증] 번개 신고 API")
     @PostMapping("/light/report/{crewId}/{lightId}/{userId}")
-    public ApiResponse reportLight(@PathVariable final Long crewId, @PathVariable final Long lightId, @PathVariable final Long userId, @RequestBody @Valid final ReportLightRequestDto request){
+    public ApiResponse reportLight(@PathVariable final Long crewId, @PathVariable final Long lightId, @PathVariable final Long userId, @RequestBody @Valid final ReportLightRequestDto request) {
         lightService.reportLight(crewId, lightId, userId, request.toServiceDto());
         return ApiResponse.success(SuccessCode.REPORT_LIGHT_SUCCESS);
     }
 
     @ApiOperation("인기 번개 조회 API")
     @GetMapping("/light/{crewId}/hot")
-    public ApiResponse<List<LightResponse>> getHotLight(@PathVariable final Long crewId){
+    public ApiResponse<List<LightResponse>> getHotLight(@PathVariable final Long crewId) {
         return ApiResponse.success(SuccessCode.HOT_LIGHT_SUCCESS, lightService.getHotLight(crewId));
     }
 
     @ApiOperation("최신 번개 조회 API")
     @GetMapping("/light/{crewId}/new")
-    public ApiResponse<List<LightResponse>> getNewLight(@PathVariable final Long crewId){
+    public ApiResponse<List<LightResponse>> getNewLight(@PathVariable final Long crewId) {
         return ApiResponse.success(SuccessCode.NEW_LIGHT_SUCCESS, lightService.getNewLight(crewId));
+    }
+
+    @ApiOperation("내가 만든 번개 리스트 조회 API")
+    @GetMapping("/light/{crewId}/{userId}/open")
+    public ApiResponse<LightResponseUsingCursorResponse> getOpenLight(@PathVariable final Long crewId, @PathVariable final Long userId, @Valid final LightScrollRequest request) {
+        return ApiResponse.success(SuccessCode.OPEN_LIGHT_SUCCESS, lightService.getOpenLight(crewId, userId, request.getSize(), request.getLastLightId())); //TODO size + lastLightId DTO로 묶기
     }
 }
 

--- a/src/main/java/com/deploy/playtogether/controller/light/dto/request/LightScrollRequest.java
+++ b/src/main/java/com/deploy/playtogether/controller/light/dto/request/LightScrollRequest.java
@@ -1,0 +1,25 @@
+package com.deploy.playtogether.controller.light.dto.request;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@ToString
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LightScrollRequest {
+    @Min(value = 1, message = "{common.size.min}")
+    @Max(value = 100, message = "{common.size.max}")
+    private int size;
+
+    @Nullable
+    private Long lastLightId;
+}

--- a/src/main/java/com/deploy/playtogether/domain/light/LightRepository.java
+++ b/src/main/java/com/deploy/playtogether/domain/light/LightRepository.java
@@ -1,11 +1,12 @@
 package com.deploy.playtogether.domain.light;
 
+import com.deploy.playtogether.domain.light.repository.LightRepositoryCustom;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface LightRepository extends JpaRepository<Light, Long>{
+public interface LightRepository extends JpaRepository<Light, Long>, LightRepositoryCustom {
     List<Light> findAllByOrderByScpCntDesc(Pageable pageable);
 
     List<Light> findAllByOrderByCreatedAtDesc(Pageable page);

--- a/src/main/java/com/deploy/playtogether/domain/light/repository/LightRepositoryCustom.java
+++ b/src/main/java/com/deploy/playtogether/domain/light/repository/LightRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.deploy.playtogether.domain.light.repository;
+
+import com.deploy.playtogether.domain.light.Light;
+
+import java.util.List;
+
+public interface LightRepositoryCustom {
+    List<Light> findAllByUserIdUsingCursor(Long userId, int size, Long lastLightId);
+}

--- a/src/main/java/com/deploy/playtogether/domain/light/repository/LightRepositoryCustomImpl.java
+++ b/src/main/java/com/deploy/playtogether/domain/light/repository/LightRepositoryCustomImpl.java
@@ -1,0 +1,41 @@
+package com.deploy.playtogether.domain.light.repository;
+
+import com.deploy.playtogether.domain.light.Light;
+import com.deploy.playtogether.domain.light.QLight;
+import com.deploy.playtogether.domain.user.QUser;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.deploy.playtogether.domain.light.QLight.light;
+
+@RequiredArgsConstructor
+public class LightRepositoryCustomImpl implements LightRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Light> findAllByUserIdUsingCursor(final Long userId, final int size, final Long lastLightId) {
+        return queryFactory
+                .select(light)
+                .from(light)
+                .where(
+                        ltLightId(lastLightId),
+                        light.user.id.eq(userId)
+                )
+                .orderBy(light.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    private BooleanExpression ltLightId(Long lastLightId) {
+        if (Objects.isNull(lastLightId)){
+            return null;
+        }
+        return light.id.lt(lastLightId);
+    }
+}

--- a/src/main/java/com/deploy/playtogether/service/light/LightService.java
+++ b/src/main/java/com/deploy/playtogether/service/light/LightService.java
@@ -87,12 +87,8 @@ public class LightService {
         Pageable page = PageRequest.of(0, 5);
         List<Light> hotLights = lightRepository.findAllByOrderByScpCntDesc(page);
 
-        return hotLights.stream()
-                .map(l -> LightResponse.of(
-                        l.getId(), l.getCategory(), l.getTitle(), l.getDate(), l.getTime(),
-                        l.getPlace(), l.getPeopleCnt(), l.getScpCnt(),
-                        l.getLightMemberCnt()
-                )).collect(Collectors.toList());
+        return getLightResponseList(hotLights);
+    }
     }
 
     @Transactional
@@ -102,12 +98,7 @@ public class LightService {
         Pageable page = PageRequest.of(0, 5);
         List<Light> newLights = lightRepository.findAllByOrderByCreatedAtDesc(page);
 
-        return newLights.stream()
-                .map(l -> LightResponse.of(
-                        l.getId(), l.getCategory(), l.getTitle(), l.getDate(), l.getTime(),
-                        l.getPlace(), l.getPeopleCnt(), l.getScpCnt(),
-                        l.getLightMemberCnt()
-                )).collect(Collectors.toList());
+        return getLightResponseList(newLights);
     }
 
     @Transactional
@@ -128,4 +119,13 @@ public class LightService {
             throw new ConflictException("해당 번개를 이미 신고한 상태입니다.", ErrorCode.CONFLICT_EXCEPTION);
         }
     }
+    @NotNull
+    private List<LightResponse> getLightResponseList(List<Light> lights) {
+        return lights.stream()
+                .map(l -> LightResponse.of(l.getId(), l.getCategory(), l.getTitle(), l.getDate(), l.getTime(),
+                        l.getPlace(), l.getPeopleCnt(), l.getScpCnt(),
+                        l.getLightMemberCnt()
+                )).collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/deploy/playtogether/service/light/dto/response/LightResponseUsingCursorResponse.java
+++ b/src/main/java/com/deploy/playtogether/service/light/dto/response/LightResponseUsingCursorResponse.java
@@ -1,0 +1,26 @@
+package com.deploy.playtogether.service.light.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.List;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LightResponseUsingCursorResponse {
+    private List<LightResponse> response;
+    private Long nextLightId;
+
+    public static LightResponseUsingCursorResponse of(final List<LightResponse> lightResponse, final Long nextLightId){
+        LightResponseUsingCursorResponse response = new LightResponseUsingCursorResponse(
+                lightResponse,
+                nextLightId
+        );
+        return response;
+    }
+}


### PR DESCRIPTION
## 🌈 PR 요약 / Linked Issue
내가 만든 번개 리스트 조회 API 구현
close #41 


## 📌 변경 사항
커서 기반 스크롤을 위해 repositoryCustom, repositoryCustomImpl + querydsl 구현
response 중복 리턴 코드 -> 메서드로 분리(refactor)
cursor를 위한 response 추가